### PR TITLE
Bomb search algorithm changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "radarflow"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radarflow"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Janek S <development@superyu.xyz"]
 edition = "2021"
 

--- a/src/dma/context/mod.rs
+++ b/src/dma/context/mod.rs
@@ -134,16 +134,6 @@ impl DmaCtx {
         Ok(ptr2)
     }
 
-    /// Professionally engineered function to quickly check if the entity has class name "weapon_c4"
-    pub fn is_dropped_c4(&mut self, entity_ptr: Address) -> anyhow::Result<bool> {
-        let entity_identity_ptr = self.process.read_addr64(entity_ptr + cs2dumper::client::CEntityInstance::m_pEntity)?;
-        let class_name_ptr = self.process.read_addr64(entity_identity_ptr + cs2dumper::client::CEntityIdentity::m_designerName)?;
-
-        let data = self.process.read_raw(class_name_ptr + 7, 2)?;
-        let is_c4 = data == "c4".as_bytes();
-        Ok(is_c4)
-    }
-
     /// Professionally engineered function to quickly check if the entity has class name "cs_player_controller"
     pub fn is_cs_player_controller(&mut self, entity_ptr: Address) -> anyhow::Result<bool> {
         let entity_identity_ptr = self.process.read_addr64(entity_ptr + cs2dumper::client::CEntityInstance::m_pEntity)?;

--- a/src/dma/threaddata/mod.rs
+++ b/src/dma/threaddata/mod.rs
@@ -42,8 +42,8 @@ impl CsData {
         if self.bomb_dropped {
             // If the bomb is dropped, do a reverse entity list loop with early exit when we found the bomb.
 
-            // We search in chunks of 512 indexes
-            for chunk in &(0..=self.highest_index).rev().into_iter().chunks(512) {
+            // We search in chunks of 64 indexes
+            for chunk in &(0..=self.highest_index).rev().into_iter().chunks(64) {
                 // data vec: (address, index, entity_identity_ptr, designer_name_ptr, designer_name_buff)
                 let mut data_vec: Vec<(u64, i32, u64, u64, [u8; 2])> = chunk
                     .map(|idx| (0u64, idx, 0u64, 0u64, [0u8; 2]))


### PR DESCRIPTION
# Changes
- Change bomb search algorithm to be fully batched
  - Use 64 as batching size
- Bump version to `0.2.4`

This change gives a significant performance uplift when searching for the dropped bomb.  

# Benchmark

Attacker: `Raspberry Pi 4 (6.8.4-1-aarch64-ARCH)`
Target: `Ryzen 9 5950X (Windows 10 Pro 22H2 19045.4291)`
Device: `Screamer PCIe Squirrel (Xilinx ARTIX-7 & FTDI FT601Q-B)`
Previously: `~253000μs`
Now: `~28500μs`